### PR TITLE
Handled missing columns in insert

### DIFF
--- a/max+python3/maxdb/exceptions.py
+++ b/max+python3/maxdb/exceptions.py
@@ -6,6 +6,12 @@ class DatabaseExists(Exception):
     pass
 
 
+class MissingColumns(Exception):
+    def __init__(self, missing_columns, *args, **kwargs):
+        self.missing_columns = missing_columns
+        super(MissingColumns, self).__init__(*args, **kwargs)
+
+
 class TableDoesNotExist(Exception):
     pass
 

--- a/max+python3/maxdb/main.py
+++ b/max+python3/maxdb/main.py
@@ -10,6 +10,7 @@ from .constants import (
 from .exceptions import (
     DatabaseDoesNotExist,
     DatabaseExists,
+    MissingColumns,
     TableDoesNotExist,
     TableExists,
     UnknownColumnNames,
@@ -73,6 +74,10 @@ def insert(db_name, table_name, row):
         if unknown_column_names:
             raise UnknownColumnNames(column_names=unknown_column_names)
 
+        missing_columns = set(table_columns) - set(row)
+        if missing_columns:
+            raise MissingColumns(missing_columns=missing_columns)
+
         ordered_keys = sorted(row.keys(), key=lambda k: table_columns.index(k))
         db[table_name][ROWS].append([row[key] for key in ordered_keys])
 
@@ -95,6 +100,7 @@ def select(db_name, table_name, columns):
 
         # Make sure it is a known column name
         unknown_column_names = set(columns) - set(table_columns)
+
         if unknown_column_names:
             raise UnknownColumnNames(column_names=unknown_column_names)
 

--- a/max+python3/maxdb/tests/test_main.py
+++ b/max+python3/maxdb/tests/test_main.py
@@ -13,6 +13,7 @@ from ..exceptions import (
     DatabaseDoesNotExist,
     DatabaseExists,
     TableExists,
+    MissingColumns,
 )
 from ..main import (
     create_database,
@@ -88,6 +89,18 @@ def test_insert():
         with open(get_db_file_name(DB_NAME), 'r') as f:
             db = json.load(f)
             assert db == {TABLE_NAME: {COLUMNS: columns, ROWS: [[row['id'], row['created'], row['name']]]}}
+    finally:
+        drop_database(DB_NAME)
+
+
+def test_insert_missing_columns():
+    create_database(DB_NAME)
+    columns = ['id', 'created', 'name']
+    create_table(DB_NAME, TABLE_NAME, columns)
+    row = {'id': 1, 'name': 'High Quality Gifs'}
+    try:
+        with pytest.raises(MissingColumns):
+            insert(DB_NAME, TABLE_NAME, row)
     finally:
         drop_database(DB_NAME)
 


### PR DESCRIPTION
This fixes a bug where `insert` allowed rows with missing columns.

Updated tests.